### PR TITLE
Add Greens functions for poloidal coils

### DIFF
--- a/cephes/ellpe.cxx
+++ b/cephes/ellpe.cxx
@@ -1,0 +1,109 @@
+/*                                                     ellpe.c
+ *
+ *     Complete elliptic integral of the second kind
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double m, y, ellpe();
+ *
+ * y = ellpe( m );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Approximates the integral
+ *
+ *
+ *            pi/2
+ *             -
+ *            | |                 2
+ * E(m)  =    |    sqrt( 1 - m sin t ) dt
+ *          | |
+ *           -
+ *            0
+ *
+ * Where m = 1 - m1, using the approximation
+ *
+ *      P(x)  -  x log x Q(x).
+ *
+ * Though there are no singularities, the argument m1 is used
+ * internally rather than m for compatibility with ellpk().
+ *
+ * E(1) = 1; E(0) = pi/2.
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE       0, 1       10000       2.1e-16     7.3e-17
+ *
+ *
+ * ERROR MESSAGES:
+ *
+ *   message         condition      value returned
+ * ellpe domain      x<0, x>1            0.0
+ *
+ */
+
+/*                                                     ellpe.c         */
+
+/* Elliptic integral of second kind */
+
+/*
+ * Cephes Math Library, Release 2.1:  February, 1989
+ * Copyright 1984, 1987, 1989 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ *
+ * Feb, 2002:  altered by Travis Oliphant
+ * so that it is called with argument m
+ * (which gets immediately converted to m1 = 1-m)
+ */
+
+#include <cmath>
+
+#include <boutexception.hxx>
+#include "polevl.h"
+
+static double P[] = {
+    1.53552577301013293365E-4,
+    2.50888492163602060990E-3,
+    8.68786816565889628429E-3,
+    1.07350949056076193403E-2,
+    7.77395492516787092951E-3,
+    7.58395289413514708519E-3,
+    1.15688436810574127319E-2,
+    2.18317996015557253103E-2,
+    5.68051945617860553470E-2,
+    4.43147180560990850618E-1,
+    1.00000000000000000299E0
+};
+
+static double Q[] = {
+    3.27954898576485872656E-5,
+    1.00962792679356715133E-3,
+    6.50609489976927491433E-3,
+    1.68862163993311317300E-2,
+    2.61769742454493659583E-2,
+    3.34833904888224918614E-2,
+    4.27180926518931511717E-2,
+    5.85936634471101055642E-2,
+    9.37499997197644278445E-2,
+    2.49999999999888314361E-1
+};
+
+double ellpe(double x) {
+  x = 1.0 - x;
+  if (x <= 0.0) {
+    if (x == 0.0)
+      return 1.0;
+    throw BoutException("Invalid argument to ellpe");
+  }
+  if (x > 1.0) {
+    return ellpe(1.0 - 1 / x) * sqrt(x);
+  }
+  return (polevl(x, P, 10) - log(x) * (x * polevl(x, Q, 9)));
+}

--- a/cephes/ellpk.cxx
+++ b/cephes/ellpk.cxx
@@ -1,0 +1,122 @@
+/*                                                     ellpk.c
+ *
+ *     Complete elliptic integral of the first kind
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double m1, y, ellpk();
+ *
+ * y = ellpk( m1 );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Approximates the integral
+ *
+ *
+ *
+ *            pi/2
+ *             -
+ *            | |
+ *            |           dt
+ * K(m)  =    |    ------------------
+ *            |                   2
+ *          | |    sqrt( 1 - m sin t )
+ *           -
+ *            0
+ *
+ * where m = 1 - m1, using the approximation
+ *
+ *     P(x)  -  log x Q(x).
+ *
+ * The argument m1 is used internally rather than m so that the logarithmic
+ * singularity at m = 1 will be shifted to the origin; this
+ * preserves maximum accuracy.
+ *
+ * K(0) = pi/2.
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE       0,1        30000       2.5e-16     6.8e-17
+ *
+ * ERROR MESSAGES:
+ *
+ *   message         condition      value returned
+ * ellpk domain       x<0, x>1           0.0
+ *
+ */
+
+/*                                                     ellpk.c */
+
+
+/*
+ * Cephes Math Library, Release 2.0:  April, 1987
+ * Copyright 1984, 1987 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+
+#include <cmath>
+
+#include <boutexception.hxx>
+#include "polevl.h"
+
+static double P[] = {
+    1.37982864606273237150E-4,
+    2.28025724005875567385E-3,
+    7.97404013220415179367E-3,
+    9.85821379021226008714E-3,
+    6.87489687449949877925E-3,
+    6.18901033637687613229E-3,
+    8.79078273952743772254E-3,
+    1.49380448916805252718E-2,
+    3.08851465246711995998E-2,
+    9.65735902811690126535E-2,
+    1.38629436111989062502E0
+};
+
+static double Q[] = {
+    2.94078955048598507511E-5,
+    9.14184723865917226571E-4,
+    5.94058303753167793257E-3,
+    1.54850516649762399335E-2,
+    2.39089602715924892727E-2,
+    3.01204715227604046988E-2,
+    3.73774314173823228969E-2,
+    4.88280347570998239232E-2,
+    7.03124996963957469739E-2,
+    1.24999999999870820058E-1,
+    4.99999999999999999821E-1
+};
+
+const double C1 = 1.3862943611198906188E0;	/* log(4) */
+
+const double MACHEP = 1e-16;
+
+double ellpk(double x) {
+
+  if (x < 0.0) {
+    throw BoutException("Input to ellpk must be positive");
+  }
+
+  if (x > 1.0) {
+    if (std::isinf(x)) {
+      return 0.0;
+    }
+    return ellpk(1 / x) / sqrt(x);
+  }
+
+  if (x > MACHEP) {
+    return (polevl(x, P, 10) - log(x) * polevl(x, Q, 10));
+  } else {
+    if (x == 0.0) {
+      throw BoutException("Input to ellpk must be non-zero");
+    } else {
+      return C1 - 0.5 * log(x);
+    }
+  }
+}

--- a/cephes/polevl.h
+++ b/cephes/polevl.h
@@ -1,0 +1,77 @@
+/*                                                     polevl.c
+ *                                                     p1evl.c
+ *
+ *     Evaluate polynomial
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * int N;
+ * double x, y, coef[N+1], polevl[];
+ *
+ * y = polevl( x, coef, N );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Evaluates polynomial of degree N:
+ *
+ *                     2          N
+ * y  =  C  + C x + C x  +...+ C x
+ *        0    1     2          N
+ *
+ * Coefficients are stored in reverse order:
+ *
+ * coef[0] = C  , ..., coef[N] = C  .
+ *            N                   0
+ *
+ *  The function p1evl() assumes that coef[N] = 1.0 and is
+ * omitted from the array.  Its calling arguments are
+ * otherwise the same as polevl().
+ *
+ *
+ * SPEED:
+ *
+ * In the interest of speed, there are no checks for out
+ * of bounds arithmetic.  This routine is used by most of
+ * the functions in the library.  Depending on available
+ * equipment features, the user may wish to rewrite the
+ * program in microcode or assembly language.
+ *
+ */
+
+
+/*
+ * Cephes Math Library Release 2.1:  December, 1988
+ * Copyright 1984, 1987, 1988 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+
+/* Sources:
+ * [1] Holin et. al., "Polynomial and Rational Function Evaluation",
+ *     https://www.boost.org/doc/libs/1_61_0/libs/math/doc/html/math_toolkit/roots/rational.html
+ */
+
+#ifndef CEPHES_POLEV
+#define CEPHES_POLEV
+
+static inline double polevl(double x, const double coef[], int N)
+{
+    double ans;
+    int i;
+    const double *p;
+
+    p = coef;
+    ans = *p++;
+    i = N;
+
+    do
+	ans = ans * x + *p++;
+    while (--i);
+
+    return (ans);
+}
+
+#endif

--- a/cephes/readme
+++ b/cephes/readme
@@ -1,0 +1,17 @@
+Cephes, as used in Scipy.special
+Source: https://www.netlib.org/cephes/
+
+   Some software in this archive may be from the book _Methods and
+Programs for Mathematical Functions_ (Prentice-Hall or Simon & Schuster
+International, 1989) or from the Cephes Mathematical Library, a
+commercial product. In either event, it is copyrighted by the author.
+What you see here may be used freely but it comes with no support or
+guarantee.
+
+   The two known misprints in the book are repaired here in the
+source listings for the gamma function and the incomplete beta
+integral.
+
+
+   Stephen L. Moshier
+   moshier@na-net.ornl.gov

--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 
 BOUT_TOP	= ../../
 
-SOURCEC		= merging-flux.cxx
+SOURCEC		= merging-flux.cxx cephes/ellpe.cxx cephes/ellpk.cxx
+TARGET = merging-flux
 
 include $(BOUT_TOP)/make.config

--- a/merging-flux.cxx
+++ b/merging-flux.cxx
@@ -8,7 +8,7 @@ protected:
   int init(bool restarting) {
     
     // Get the magnetic field
-    Coordinates *coord = mesh->coordinates();
+    Coordinates *coord = mesh->getCoordinates();
     B0 = coord->Bxy;
     R = sqrt(coord->g_22);
     

--- a/toroidal-breakdown/BOUT.inp
+++ b/toroidal-breakdown/BOUT.inp
@@ -1,0 +1,124 @@
+#
+# 
+
+nout = 20
+timestep = 1
+
+MYG = 0
+
+ZMAX = mesh:Lz/(2*pi) # Sets dz
+
+[mesh]
+
+Lx = 1.8   # X size in meters (0.2 to 2.0 in MAST)
+Lz = 4.4   # Z size in meters (-2.2 to +2.2 in MAST)
+
+nx = 68    # number of points in X, including 4 guard cells
+ny = 1     # Axisymmetric
+nz = 128    # Number of points in Z
+
+# Parallel current density
+
+mu0 = 4e-7*pi
+
+jm = mu0 * 0.8e6  # Maximum current density [A/m^2] normalised to mu0
+w = 0.4  # Width of the current filaments
+
+X0 = 0.9 # X location of the filaments
+Z1 = 2.2+0.6 # Z location of filament 1
+Z2 = 2.2-0.6 # Z location of filament 2
+
+R1 = sqrt((xpos-X0)^2 + (zpos-Z1)^2) # Radius from centre of filament 0
+R2 = sqrt((xpos-X0)^2 + (zpos-Z2)^2) # Radius from centre of filament 1
+
+filament1 = H(w - R1)*jm*(1-(R1/w)^2)^2
+filament2 = H(w - R2)*jm*(1-(R2/w)^2)^2
+
+Jpar = 0.0  # No starting current
+
+RBt = 0.5  # R*Bt in [m][T]
+
+######################
+
+
+xpos = x * Lx          # X position [m]
+zpos = z * Lz / (2*pi) # Z position [m]
+
+Rxy = xpos + 0.2  # Major radius [m]
+
+Bxy = RBt / Rxy # Magnetic field in Tesla
+
+# The x direction is (toroidal) flux dx = B*dlx
+g11 = Bxy^2
+g_11 = 1/g11
+
+# The y direction is toroidal angle
+g22 = 1/Rxy^2
+g_22 = 1/g22
+
+# The z direction is height dz = dlz
+
+J = Rxy / Bxy
+
+dx = Bxy * Lx/nx  # Flux
+ZMAX = Lz/(2*pi) # Sets dz
+
+[solver]  # Time integration solver
+
+
+[phisolver]
+type=cyclic
+dst = true
+nonuniform = true
+
+[psisolver]
+type = cyclic
+dst = true
+nonuniform = true
+
+[laplace]
+nonuniform = true
+
+
+[model]
+
+viscosity = 5e-4    # Normalised Braginskii is 5.629712e-10, gyro 7.248928e-07
+resistivity = 5e-6  # Normalised Braginskii is 2.220479e-06
+
+Bv = 0.0 # External vertical field [T]
+
+###################################
+# Pair of Helmholtz coils to produce a vertical field, setting psiext (external flux)
+
+Rcoil = 2.0  # Radial location of coils [m]
+Zcoil1 = 2.2 + 1.0 # Height of coil1 [m]
+Zcoil2 = 2.2 - 1.0 # Height of coil2 [m]
+Bcentre = 0.03  # Vertical magnetic field at centre [T]
+mu0 = 4e-7*pi
+
+Icoil = Bcentre * Rcoil * (5/4)^1.5 / mu0   # Current*turns in each coil
+
+# Calculate poloidal flux due to pair of coils
+psi_helmholtz = Icoil * (coil_greens(Rcoil, Zcoil1, mesh:Rxy, mesh:zpos) + coil_greens(Rcoil, Zcoil2, mesh:Rxy, mesh:zpos))
+
+####################################
+# A pair of coils to be used for breakdown.
+# These start with finite current, and ramp down to zero
+
+# Define poloidal flux due to unit current in each coil
+shape_psi = coil_greens(0.9, 2.2 + 0.6, mesh:Rxy, mesh:zpos)# + coil_greens(0.9, 2.2 - 0.6, mesh:Rxy, mesh:zpos)
+
+tau_breakdown = 1e-4 # Timescale for breakdown [seconds]
+Istart = 1e4 # Starting current in each coil [Amps]
+
+# Note: Here "t" is the simulation time in seconds. H(x) = 0 if x < 0 i.e. if t > tau_breakdown.
+psi_breakdown = Istart * cos(t / tau_breakdown * (π/2)) * H(tau_breakdown - t) * shape_psi
+
+# Electric field: E = -dA/dt = - d/dt(psi/R)
+Eext = Istart * (π/2)/tau_breakdown * sin(t / tau_breakdown * (π/2)) * H(tau_breakdown - t) * shape_psi / mesh:Rxy
+
+####################################
+# External poloidal flux psiext
+# Sum of helmholtz coils (vertical field) and breakdown coils
+
+psiext = psi_breakdown + psi_helmholtz

--- a/toroidal-coils/BOUT.inp
+++ b/toroidal-coils/BOUT.inp
@@ -1,0 +1,101 @@
+#
+# 
+
+nout = 100
+timestep = 1
+
+MYG = 0
+
+ZMAX = mesh:Lz/(2*pi) # Sets dz
+
+[mesh]
+
+Lx = 1.8   # X size in meters (0.2 to 2.0 in MAST)
+Lz = 4.4   # Z size in meters (-2.2 to +2.2 in MAST)
+
+nx = 68    # number of points in X, including 4 guard cells
+ny = 1     # Axisymmetric
+nz = 128    # Number of points in Z
+
+# Parallel current density
+
+mu0 = 4e-7*pi
+
+jm = mu0 * 0.8e6  # Maximum current density [A/m^2] normalised to mu0
+w = 0.4  # Width of the current filaments
+
+X0 = 0.9 # X location of the filaments
+Z1 = 2.2+0.6 # Z location of filament 1
+Z2 = 2.2-0.6 # Z location of filament 2
+
+R1 = sqrt((xpos-X0)^2 + (zpos-Z1)^2) # Radius from centre of filament 0
+R2 = sqrt((xpos-X0)^2 + (zpos-Z2)^2) # Radius from centre of filament 1
+
+filament1 = H(w - R1)*jm*(1-(R1/w)^2)^2
+filament2 = H(w - R2)*jm*(1-(R2/w)^2)^2
+
+Jpar = filament1 + filament2
+
+RBt = 0.5  # R*Bt in [m][T]
+
+######################
+
+
+xpos = x * Lx          # X position [m]
+zpos = z * Lz / (2*pi) # Z position [m]
+
+Rxy = xpos + 0.2  # Major radius [m]
+
+Bxy = RBt / Rxy # Magnetic field in Tesla
+
+# The x direction is (toroidal) flux dx = B*dlx
+g11 = Bxy^2
+g_11 = 1/g11
+
+# The y direction is toroidal angle
+g22 = 1/Rxy^2
+g_22 = 1/g22
+
+# The z direction is height dz = dlz
+
+J = Rxy / Bxy
+
+dx = Bxy * Lx/nx  # Flux
+ZMAX = Lz/(2*pi) # Sets dz
+
+[solver]  # Time integration solver
+
+
+[phisolver]
+type=cyclic
+dst = true
+nonuniform = true
+
+[psisolver]
+type = cyclic
+dst = true
+nonuniform = true
+
+[laplace]
+nonuniform = true
+
+
+[model]
+
+viscosity = 5e-4    # Normalised Braginskii is 5.629712e-10, gyro 7.248928e-07
+resistivity = 5e-6  # Normalised Braginskii is 2.220479e-06
+
+Bv = 0.0 # External vertical field [T]
+
+# Pair of Helmholtz coils to produce a vertical field, setting psiext (external flux)
+
+Rcoil = 2.0  # Radial location of coils [m]
+Zcoil1 = 2.2 + 1.0 # Height of coil1 [m]
+Zcoil2 = 2.2 - 1.0 # Height of coil2 [m]
+Bcentre = 0.03  # Vertical magnetic field at centre [T]
+mu0 = 4e-7*pi
+
+Icoil = Bcentre * Rcoil * (5/4)^1.5 / mu0   # Current*turns in each coil
+
+# Calculate poloidal flux due to pair of coils
+psiext = Icoil * (coil_greens(Rcoil, Zcoil1, mesh:Rxy, mesh:zpos) + coil_greens(Rcoil, Zcoil2, mesh:Rxy, mesh:zpos))


### PR DESCRIPTION
Uses part of the Cephes library to calculate the elliptic integrals needed.
Allows coils to be added in the BOUT.inp settings file.